### PR TITLE
ci: notify VSCodeMCP extension on PyPI publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -137,3 +137,18 @@ jobs:
             --title "v${{ needs.build.outputs.version }}" \
             --generate-notes \
             --repo '${{ github.repository }}' || echo "Release already exists, skipping"
+
+  notify-vscode-extension:
+    name: Notify VS Code Extension
+    if: github.event_name == 'push'
+    needs: [publish-pypi]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger VSCodeMCP rebuild
+        run: |
+          curl -s -X POST \
+            -H "Authorization: token ${{ secrets.VSCODE_MCP_DISPATCH_TOKEN }}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            "https://api.github.com/repos/AceDataCloud/VSCodeMCP/dispatches" \
+            -d '{"event_type":"mcp-updated","client_payload":{"source":"${{ github.repository }}","version":"${{ needs.build.outputs.version }}"}}'
+          echo "Triggered VSCodeMCP extension rebuild"


### PR DESCRIPTION
Adds a  job to the publish workflow.\n\nAfter a successful PyPI publish, this dispatches a  event to , triggering an automatic VS Code extension republish with the latest MCP server versions.\n\nThis ensures the VS Code Marketplace extension stays in sync whenever any MCP server is updated.