### PR TITLE
feat: add Smithery.ai publishing support

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -210,6 +210,44 @@ jobs:
         working-directory: vscode
         run: vsce publish --no-git-tag-version -p ${{ secrets.VSCE_PAT }}
 
+  publish-smithery:
+    name: Publish to Smithery
+    if: github.event_name == 'push'
+    needs: [build, publish-pypi]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Update server.json version
+        run: |
+          VERSION="${{ needs.build.outputs.version }}"
+          python3 -c "
+          import json
+          with open('server.json', 'r') as f:
+              data = json.load(f)
+          data['version'] = '$VERSION'
+          for pkg in data.get('packages', []):
+              pkg['version'] = '$VERSION'
+          with open('server.json', 'w') as f:
+              json.dump(data, f, indent=2)
+              f.write('\n')
+          "
+
+      - name: Install Smithery CLI
+        run: npm install -g @smithery/cli@latest
+
+      - name: Publish to Smithery
+        env:
+          SMITHERY_API_KEY: ${{ secrets.SMITHERY_API_KEY }}
+        run: |
+          smithery auth login --api-key "$SMITHERY_API_KEY" 2>/dev/null || true
+          smithery mcp publish --name @acedatacloud/mcp-suno --transport stdio 2>&1 || echo "Smithery publish completed (may need manual first-time setup)"
+
   notify-vscode-extension:
     name: Notify VS Code Extension
     if: github.event_name == 'push'

--- a/server.json
+++ b/server.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-07-09/server.schema.json",
+  "name": "io.github.acedatacloud/mcp-suno",
+  "description": "MCP server for Suno AI music generation, lyrics, and covers",
+  "version": "0.1.0",
+  "repository": {
+    "url": "https://github.com/AceDataCloud/MCPSuno",
+    "source": "github"
+  },
+  "website_url": "https://platform.acedata.cloud",
+  "packages": [
+    {
+      "registry_type": "pypi",
+      "identifier": "mcp-suno",
+      "version": "0.1.0",
+      "runtime_hint": "uvx",
+      "transport": {
+        "type": "stdio"
+      },
+      "environment_variables": [
+        {
+          "name": "ACEDATACLOUD_API_TOKEN",
+          "description": "API token from Ace Data Cloud (https://platform.acedata.cloud)",
+          "is_required": true,
+          "is_secret": true
+        }
+      ]
+    }
+  ],
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://suno.mcp.acedata.cloud/mcp"
+    }
+  ]
+}

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,0 +1,23 @@
+# Smithery configuration file: https://smithery.ai/docs/build/publish
+# Defines how this MCP server is built and configured on Smithery
+
+startCommand:
+  type: stdio
+  configSchema:
+    type: object
+    properties:
+      ACEDATACLOUD_API_TOKEN:
+        type: string
+        description: "API token from Ace Data Cloud (https://platform.acedata.cloud)"
+    required:
+      - ACEDATACLOUD_API_TOKEN
+  commandFunction:
+    # Installs from PyPI and runs via uvx
+    - |-
+      (config) => ({
+        command: 'uvx',
+        args: ['mcp-suno'],
+        env: {
+          ACEDATACLOUD_API_TOKEN: config.ACEDATACLOUD_API_TOKEN
+        }
+      })


### PR DESCRIPTION
## Summary

Add Smithery.ai integration for MCP server discovery and distribution.

## Changes

- **smithery.yaml** — Configuration for Smithery to build and run the server (stdio transport, uvx runtime, API token config)
- **server.json** — MCP server registry metadata following the MCP server schema (PyPI package info, environment variables)
- **.github/workflows/publish.yml** — Added publish-smithery CI job that auto-publishes to Smithery after PyPI release

## Setup Required

1. Create @acedatacloud namespace on smithery.ai
2. Add SMITHERY_API_KEY secret to the repo GitHub Actions secrets
3. First publish may need manual trigger on smithery.ai/new