### PR TITLE
fix: skip JetBrains publish when no token

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -312,4 +312,9 @@ jobs:
         working-directory: jetbrains
         env:
           PUBLISH_TOKEN: ${{ secrets.JETBRAINS_MARKETPLACE_TOKEN }}
-        run: ./gradlew publishPlugin
+        run: |
+          if [ -z "$PUBLISH_TOKEN" ]; then
+            echo "JETBRAINS_MARKETPLACE_TOKEN not set, skipping publish"
+            exit 0
+          fi
+          ./gradlew publishPlugin

--- a/jetbrains/.gitignore
+++ b/jetbrains/.gitignore
@@ -11,3 +11,4 @@ build/
 *.ipr
 out/
 .intellijPlatform/
+.kotlin/


### PR DESCRIPTION
- Skip publishPlugin gracefully when JETBRAINS_MARKETPLACE_TOKEN secret is not set
- Add .kotlin/ to jetbrains/.gitignore