### PR TITLE
fix: revert endpoint path from /mc back to /mcp

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Generate AI music, lyrics, and manage audio projects directly from Claude, VS Co
 
 AceDataCloud hosts a managed MCP server — **no local installation required**.
 
-**Endpoint:** `https://suno.mcp.acedata.cloud/mc`
+**Endpoint:** `https://suno.mcp.acedata.cloud/mcp`
 
 All requests require a Bearer token. Use the API token from Step 1.
 
@@ -44,7 +44,7 @@ All requests require a Bearer token. Use the API token from Step 1.
 Connect directly on [Claude.ai](https://claude.ai) with OAuth — **no API token needed**:
 
 1. Go to Claude.ai **Settings → Integrations → Add More**
-2. Enter the server URL: `https://suno.mcp.acedata.cloud/mc`
+2. Enter the server URL: `https://suno.mcp.acedata.cloud/mcp`
 3. Complete the OAuth login flow
 4. Start using the tools in your conversation
 
@@ -57,7 +57,7 @@ Add to your config (`~/Library/Application Support/Claude/claude_desktop_config.
   "mcpServers": {
     "suno": {
       "type": "streamable-http",
-      "url": "https://suno.mcp.acedata.cloud/mc",
+      "url": "https://suno.mcp.acedata.cloud/mcp",
       "headers": {
         "Authorization": "Bearer YOUR_API_TOKEN"
       }
@@ -75,7 +75,7 @@ Add to your MCP config (`.cursor/mcp.json` or `.windsurf/mcp.json`):
   "mcpServers": {
     "suno": {
       "type": "streamable-http",
-      "url": "https://suno.mcp.acedata.cloud/mc",
+      "url": "https://suno.mcp.acedata.cloud/mcp",
       "headers": {
         "Authorization": "Bearer YOUR_API_TOKEN"
       }
@@ -93,7 +93,7 @@ Add to your VS Code MCP config (`.vscode/mcp.json`):
   "servers": {
     "suno": {
       "type": "streamable-http",
-      "url": "https://suno.mcp.acedata.cloud/mc",
+      "url": "https://suno.mcp.acedata.cloud/mcp",
       "headers": {
         "Authorization": "Bearer YOUR_API_TOKEN"
       }
@@ -114,7 +114,7 @@ Or install the [Ace Data Cloud MCP extension](https://marketplace.visualstudio.c
 {
   "mcpServers": {
     "suno": {
-      "url": "https://suno.mcp.acedata.cloud/mc",
+      "url": "https://suno.mcp.acedata.cloud/mcp",
       "headers": {
         "Authorization": "Bearer YOUR_API_TOKEN"
       }
@@ -130,7 +130,7 @@ Or install the [Ace Data Cloud MCP extension](https://marketplace.visualstudio.c
 curl https://suno.mcp.acedata.cloud/health
 
 # MCP initialize
-curl -X POST https://suno.mcp.acedata.cloud/mc \
+curl -X POST https://suno.mcp.acedata.cloud/mcp \
   -H "Content-Type: application/json" \
   -H "Accept: application/json" \
   -H "Authorization: Bearer YOUR_API_TOKEN" \

--- a/main.py
+++ b/main.py
@@ -286,7 +286,7 @@ Environment Variables:
 
             mcp.settings.stateless_http = True
             mcp.settings.json_response = True
-            mcp.settings.streamable_http_path = "/mc"
+            mcp.settings.streamable_http_path = "/mcp"
 
             # Build routes
             routes: list[Route | Mount] = [


### PR DESCRIPTION
Revert streamable HTTP path to /mcp and update README accordingly.