### PR TITLE
feat: add individual OAuth client ID

### DIFF
--- a/deploy/production/deployment.yaml
+++ b/deploy/production/deployment.yaml
@@ -31,6 +31,8 @@ spec:
           env:
             - name: MCP_SERVER_URL
               value: "https://suno.mcp.acedata.cloud"
+            - name: ACEDATACLOUD_OAUTH_CLIENT_ID
+              value: "jzgkKj3lhBNXLb73kw9M-2ZuDuRYoUf73CUcY_P4QII"
           resources:
             limits:
               cpu: 500m


### PR DESCRIPTION
Add individual ACEDATACLOUD_OAUTH_CLIENT_ID env var for per-MCP-server OAuth authentication. Each MCP server now has its own OAuth application in the database with proper name, icon, and redirect URI. This allows the OAuth consent page to dynamically display the correct service icon.
