### PR TITLE
feat: add chirp-v5-5 support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,7 +6,7 @@ ACEDATACLOUD_API_TOKEN=your_api_token_here
 ACEDATACLOUD_API_BASE_URL=https://api.acedata.cloud
 
 # Suno Configuration (Optional)
-SUNO_DEFAULT_MODEL=chirp-v4-5
+SUNO_DEFAULT_MODEL=chirp-v5-5
 SUNO_REQUEST_TIMEOUT=1800
 
 # MCP Server Configuration (Optional)

--- a/README.md
+++ b/README.md
@@ -396,6 +396,7 @@ Claude: I'll extend the song with a bridge.
 
 | Model             | Version | Max Duration | Features             |
 | ----------------- | ------- | ------------ | -------------------- |
+| `chirp-v5-5`      | V5.5    | 8 minutes    | Latest, best quality |
 | `chirp-v5`        | V5      | 8 minutes    | Latest, best quality |
 | `chirp-v4-5-plus` | V4.5+   | 8 minutes    | Enhanced quality     |
 | `chirp-v4-5`      | V4.5    | 4 minutes    | Vocal gender control |
@@ -418,7 +419,7 @@ Claude: I'll extend the song with a bridge.
 | `ACEDATACLOUD_API_BASE_URL` | API base URL                 | `https://api.acedata.cloud` |
 | `ACEDATACLOUD_OAUTH_CLIENT_ID`  | OAuth client ID (hosted mode) | —                           |
 | `ACEDATACLOUD_PLATFORM_BASE_URL` | Platform base URL            | `https://platform.acedata.cloud` |
-| `SUNO_DEFAULT_MODEL`        | Default model for generation | `chirp-v4-5`                |
+| `SUNO_DEFAULT_MODEL`        | Default model for generation | `chirp-v5-5`                |
 | `SUNO_REQUEST_TIMEOUT`      | Request timeout in seconds   | `1800`                      |
 | `LOG_LEVEL`                 | Logging level                | `INFO`                      |
 

--- a/core/config.py
+++ b/core/config.py
@@ -23,7 +23,7 @@ class Settings:
 
     # Default Model
     default_model: str = field(
-        default_factory=lambda: os.getenv("SUNO_DEFAULT_MODEL", "chirp-v4-5")
+        default_factory=lambda: os.getenv("SUNO_DEFAULT_MODEL", "chirp-v5-5")
     )
 
     # Request Configuration

--- a/core/types.py
+++ b/core/types.py
@@ -9,6 +9,7 @@ SunoModel = Literal[
     "chirp-v4",
     "chirp-v4-5",
     "chirp-v4-5-plus",
+    "chirp-v5-5",
     "chirp-v5",
 ]
 
@@ -19,7 +20,7 @@ LyricsModel = Literal["default", "remi-v1"]
 VocalGender = Literal["", "f", "m"]
 
 # Default model
-DEFAULT_MODEL: SunoModel = "chirp-v4-5"
+DEFAULT_MODEL: SunoModel = "chirp-v5-5"
 
 # Default lyrics model
 DEFAULT_LYRICS_MODEL: LyricsModel = "default"

--- a/main.py
+++ b/main.py
@@ -60,7 +60,7 @@ Examples:
 
 Environment Variables:
   ACEDATACLOUD_API_TOKEN          API token from AceDataCloud (required)
-  SUNO_DEFAULT_MODEL         Default model (default: chirp-v4-5)
+    SUNO_DEFAULT_MODEL         Default model (default: chirp-v5-5)
   SUNO_REQUEST_TIMEOUT       Request timeout in seconds (default: 1800)
   LOG_LEVEL                  Logging level (default: INFO)
         """,

--- a/prompts/__init__.py
+++ b/prompts/__init__.py
@@ -65,8 +65,8 @@ When the user wants to generate music, choose the appropriate tool based on thei
 ## Important Notes:
 1. Music generation is async in MCP - generation tools should return quickly with a task_id
 2. After any generate/extend/cover/remaster/stems/media conversion call, use `suno_get_task` to poll for the final result
-2. Default model is chirp-v4-5 (good balance of quality and speed)
-3. For longest songs (8 min), use chirp-v5 or chirp-v4-5-plus
+2. Default model is chirp-v5-5 (latest generation quality)
+3. For longest songs (8 min), use chirp-v5-5, chirp-v5, or chirp-v4-5-plus
 4. Vocal gender only works on v4.5+ models
 """
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -13,7 +13,7 @@ def test_settings_default_values():
 
         settings = Settings()
         assert settings.api_base_url == "https://api.acedata.cloud"
-        assert settings.default_model == "chirp-v4-5"
+        assert settings.default_model == "chirp-v5-5"
         assert settings.request_timeout == 1800.0
         assert settings.server_name == "suno"
         assert settings.transport == "stdio"
@@ -24,7 +24,7 @@ def test_settings_from_environment():
     env_vars = {
         "ACEDATACLOUD_API_TOKEN": "my-token",
         "ACEDATACLOUD_API_BASE_URL": "https://custom.api.com",
-        "SUNO_DEFAULT_MODEL": "chirp-v5",
+        "SUNO_DEFAULT_MODEL": "chirp-v5-5",
         "SUNO_REQUEST_TIMEOUT": "300",
         "MCP_SERVER_NAME": "my-suno",
         "LOG_LEVEL": "DEBUG",
@@ -36,7 +36,7 @@ def test_settings_from_environment():
         settings = Settings()
         assert settings.api_token == "my-token"
         assert settings.api_base_url == "https://custom.api.com"
-        assert settings.default_model == "chirp-v5"
+        assert settings.default_model == "chirp-v5-5"
         assert settings.request_timeout == 300.0
         assert settings.server_name == "my-suno"
         assert settings.log_level == "DEBUG"

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -114,6 +114,7 @@ class TestInfoTools:
         print("\n=== List Models Result ===")
         print(result)
 
+        assert "chirp-v5-5" in result
         assert "chirp-v5" in result
         assert "chirp-v4-5" in result
         assert "chirp-v3" in result

--- a/tools/audio_tools.py
+++ b/tools/audio_tools.py
@@ -21,7 +21,7 @@ async def suno_generate_music(
     model: Annotated[
         SunoModel,
         Field(
-            description="Suno model version. 'chirp-v4-5' is recommended for most use cases. 'chirp-v5' offers best quality with 8-minute max duration. Older models (v3, v3-5, v4) have shorter duration limits."
+            description="Suno model version. 'chirp-v5-5' is the latest recommended model. 'chirp-v5' also offers high quality with 8-minute max duration. Older models (v3, v3-5, v4) have shorter duration limits."
         ),
     ] = DEFAULT_MODEL,
     instrumental: Annotated[
@@ -83,7 +83,7 @@ async def suno_generate_custom_music(
     model: Annotated[
         SunoModel,
         Field(
-            description="Suno model version. 'chirp-v4-5' or 'chirp-v5' recommended for best quality."
+            description="Suno model version. 'chirp-v5-5' is recommended for the newest quality. 'chirp-v5' is also recommended for strong V5 output quality."
         ),
     ] = DEFAULT_MODEL,
     instrumental: Annotated[

--- a/tools/info_tools.py
+++ b/tools/info_tools.py
@@ -12,6 +12,7 @@ async def suno_list_models() -> str:
     for your music generation.
 
     Model comparison:
+    - chirp-v5-5: Latest and best quality, 8-minute max duration
     - chirp-v5: Latest and best quality, 8-minute max duration
     - chirp-v4-5-plus: High quality with 8-minute duration
     - chirp-v4-5: Recommended balance of quality and speed, 4-minute duration
@@ -25,6 +26,7 @@ async def suno_list_models() -> str:
 
 | Model           | Version | Prompt Limit | Lyric Limit  | Style Limit | Max Duration |
 |-----------------|---------|--------------|--------------|-------------|--------------|
+| chirp-v5-5      | V5.5    | 200 chars    | 5000 chars   | 1000 chars  | 8 minutes    |
 | chirp-v5        | V5      | 200 chars    | 5000 chars   | 1000 chars  | 8 minutes    |
 | chirp-v4-5-plus | V4.5+   | 200 chars    | 5000 chars   | 1000 chars  | 8 minutes    |
 | chirp-v4-5      | V4.5    | 200 chars    | 5000 chars   | 1000 chars  | 4 minutes    |
@@ -32,9 +34,10 @@ async def suno_list_models() -> str:
 | chirp-v3-5      | V3.5    | 200 chars    | 3000 chars   | 200 chars   | 120 seconds  |
 | chirp-v3-0      | V3      | 200 chars    | 3000 chars   | 200 chars   | 120 seconds  |
 
-Recommended: chirp-v4-5 for most use cases, chirp-v5 for best quality.
+Recommended: chirp-v5-5 for the newest quality, chirp-v5 for broad V5 compatibility.
 
 Features by Version:
+- V5.5: Newest model generation currently available in Ace Data Cloud
 - V4.5+: Vocal gender control ('f' for female, 'm' for male)
 - V5: Latest model with improved quality and 8-minute songs
 """


### PR DESCRIPTION
## Summary
- add chirp-v5-5 to the supported MCP model list
- make chirp-v5-5 the MCP default model in config and docs
- update tests and informational tool output for the new model