### PR TITLE
feat: add chirp-v5-5 model support

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,7 +396,8 @@ Claude: I'll extend the song with a bridge.
 
 | Model             | Version | Max Duration | Features             |
 | ----------------- | ------- | ------------ | -------------------- |
-| `chirp-v5`        | V5      | 8 minutes    | Latest, best quality |
+| `chirp-v5-5`      | V5.5    | 8 minutes    | Latest, best quality |
+| `chirp-v5`        | V5      | 8 minutes    | High quality         |
 | `chirp-v4-5-plus` | V4.5+   | 8 minutes    | Enhanced quality     |
 | `chirp-v4-5`      | V4.5    | 4 minutes    | Vocal gender control |
 | `chirp-v4`        | V4      | 150 seconds  | Stable               |

--- a/core/types.py
+++ b/core/types.py
@@ -10,6 +10,7 @@ SunoModel = Literal[
     "chirp-v4-5",
     "chirp-v4-5-plus",
     "chirp-v5",
+    "chirp-v5-5",
 ]
 
 # Lyrics model versions (different from audio models)

--- a/prompts/__init__.py
+++ b/prompts/__init__.py
@@ -66,7 +66,7 @@ When the user wants to generate music, choose the appropriate tool based on thei
 1. Music generation is async in MCP - generation tools should return quickly with a task_id
 2. After any generate/extend/cover/remaster/stems/media conversion call, use `suno_get_task` to poll for the final result
 2. Default model is chirp-v4-5 (good balance of quality and speed)
-3. For longest songs (8 min), use chirp-v5 or chirp-v4-5-plus
+3. For longest songs (8 min), use chirp-v5-5 or chirp-v4-5-plus
 4. Vocal gender only works on v4.5+ models
 """
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -114,6 +114,7 @@ class TestInfoTools:
         print("\n=== List Models Result ===")
         print(result)
 
+        assert "chirp-v5-5" in result
         assert "chirp-v5" in result
         assert "chirp-v4-5" in result
         assert "chirp-v3" in result

--- a/tools/audio_tools.py
+++ b/tools/audio_tools.py
@@ -21,7 +21,7 @@ async def suno_generate_music(
     model: Annotated[
         SunoModel,
         Field(
-            description="Suno model version. 'chirp-v4-5' is recommended for most use cases. 'chirp-v5' offers best quality with 8-minute max duration. Older models (v3, v3-5, v4) have shorter duration limits."
+            description="Suno model version. 'chirp-v4-5' is recommended for most use cases. 'chirp-v5-5' offers best quality with 8-minute max duration. Older models (v3, v3-5, v4) have shorter duration limits."
         ),
     ] = DEFAULT_MODEL,
     instrumental: Annotated[
@@ -83,7 +83,7 @@ async def suno_generate_custom_music(
     model: Annotated[
         SunoModel,
         Field(
-            description="Suno model version. 'chirp-v4-5' or 'chirp-v5' recommended for best quality."
+            description="Suno model version. 'chirp-v4-5' or 'chirp-v5-5' recommended for best quality."
         ),
     ] = DEFAULT_MODEL,
     instrumental: Annotated[

--- a/tools/info_tools.py
+++ b/tools/info_tools.py
@@ -12,7 +12,8 @@ async def suno_list_models() -> str:
     for your music generation.
 
     Model comparison:
-    - chirp-v5: Latest and best quality, 8-minute max duration
+    - chirp-v5-5: Latest and best quality, 8-minute max duration
+    - chirp-v5: High quality, 8-minute max duration
     - chirp-v4-5-plus: High quality with 8-minute duration
     - chirp-v4-5: Recommended balance of quality and speed, 4-minute duration
     - chirp-v4: Good quality, 150 seconds max
@@ -25,6 +26,7 @@ async def suno_list_models() -> str:
 
 | Model           | Version | Prompt Limit | Lyric Limit  | Style Limit | Max Duration |
 |-----------------|---------|--------------|--------------|-------------|--------------|
+| chirp-v5-5      | V5.5    | 200 chars    | 5000 chars   | 1000 chars  | 8 minutes    |
 | chirp-v5        | V5      | 200 chars    | 5000 chars   | 1000 chars  | 8 minutes    |
 | chirp-v4-5-plus | V4.5+   | 200 chars    | 5000 chars   | 1000 chars  | 8 minutes    |
 | chirp-v4-5      | V4.5    | 200 chars    | 5000 chars   | 1000 chars  | 4 minutes    |
@@ -32,11 +34,11 @@ async def suno_list_models() -> str:
 | chirp-v3-5      | V3.5    | 200 chars    | 3000 chars   | 200 chars   | 120 seconds  |
 | chirp-v3-0      | V3      | 200 chars    | 3000 chars   | 200 chars   | 120 seconds  |
 
-Recommended: chirp-v4-5 for most use cases, chirp-v5 for best quality.
+Recommended: chirp-v4-5 for most use cases, chirp-v5-5 for best quality.
 
 Features by Version:
 - V4.5+: Vocal gender control ('f' for female, 'm' for male)
-- V5: Latest model with improved quality and 8-minute songs
+- V5.5: Latest model with improved quality and 8-minute songs
 """
 
 


### PR DESCRIPTION
## Summary
Add support for the new Suno chirp-v5-5 model.

## Changes
- Add `chirp-v5-5` to `SunoModel` Literal type in `core/types.py`
- Update model tables in `tools/info_tools.py` and `README.md`
- Update tool descriptions to recommend `chirp-v5-5` for best quality
- Update prompts to reference `chirp-v5-5` for longest songs
- Update integration test to verify `chirp-v5-5` appears in model list