### PR TITLE
feat: add auto-sync from Docs pipeline

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,57 @@
+name: Auto-merge bot PRs
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    # Only auto-merge PRs created by the bot or Claude
+    if: |
+      github.event.pull_request.user.login == 'AceDataCloudDev' ||
+      github.event.pull_request.user.login == 'github-actions[bot]' ||
+      contains(github.event.pull_request.title, '[auto-sync]')
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Wait for CI checks
+        env:
+          GH_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN }}
+        run: |
+          pr_number=${{ github.event.pull_request.number }}
+          echo "Waiting for CI checks on PR #$pr_number..."
+          max_attempts=30
+          for i in $(seq 1 $max_attempts); do
+            sleep 30
+            # Check if all required checks have passed
+            status=$(gh pr checks "$pr_number" --json name,state --jq '[.[] | select(.name != "auto-merge")] | if length == 0 then "pass" elif all(.state == "SUCCESS" or .state == "SKIPPED") then "pass" elif any(.state == "FAILURE") then "fail" else "pending" end' 2>/dev/null || echo "pending")
+            echo "Attempt $i/$max_attempts: status=$status"
+            if [ "$status" = "pass" ]; then
+              echo "All checks passed!"
+              break
+            elif [ "$status" = "fail" ]; then
+              echo "CI checks failed. Skipping auto-merge."
+              exit 0
+            fi
+          done
+
+      - name: Approve PR
+        env:
+          GH_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN }}
+        run: |
+          gh pr review ${{ github.event.pull_request.number }} --approve
+
+      - name: Enable auto-merge
+        env:
+          GH_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN }}
+        run: |
+          gh pr merge ${{ github.event.pull_request.number }} \
+            --auto --squash \
+            --subject "sync: auto-merge from Docs update [automated]"

--- a/.github/workflows/sync-from-docs.yml
+++ b/.github/workflows/sync-from-docs.yml
@@ -1,0 +1,166 @@
+name: Sync from Docs
+
+on:
+  repository_dispatch:
+    types: [docs-updated]
+  workflow_dispatch:
+    inputs:
+      force:
+        description: "Force sync even without detected changes"
+        required: false
+        default: "false"
+        type: boolean
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+  id-token: write
+
+jobs:
+  create-sync-issue:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout this repo
+        uses: actions/checkout@v4
+
+      - name: Checkout Docs repo
+        uses: actions/checkout@v4
+        with:
+          repository: AceDataCloud/Docs
+          path: _docs
+          token: ${{ secrets.BOT_GITHUB_TOKEN }}
+
+      - name: Gather Docs changes
+        id: changes
+        run: |
+          cd _docs
+          # Get recent changes relevant to Suno
+          diff_info=$(git log -1 --pretty=format:"%h %s" 2>/dev/null || echo "unknown")
+          echo "commit_info=$diff_info" >> "$GITHUB_OUTPUT"
+
+          # Collect the current Suno-related docs content
+          echo "## Changed Docs Content" > /tmp/docs_context.md
+          echo "" >> /tmp/docs_context.md
+
+          # OpenAPI spec for suno
+          if [ -f openapi/suno.json ]; then
+            echo "### OpenAPI Spec (openapi/suno.json)" >> /tmp/docs_context.md
+            echo '```json' >> /tmp/docs_context.md
+            # Extract model enums and key fields
+            python3 -c "
+          import json
+          with open('openapi/suno.json') as f:
+              spec = json.load(f)
+          # Print paths
+          for path, methods in spec.get('paths', {}).items():
+              for method, op in methods.items():
+                  print(f'{method.upper()} {path}: {op.get(\"summary\", \"\")}')
+          # Print model enum if found
+          for path, methods in spec.get('paths', {}).items():
+              for method, op in methods.items():
+                  rb = op.get('requestBody', {})
+                  content = rb.get('content', {})
+                  for ct, mt in content.items():
+                      schema = mt.get('schema', {})
+                      props = schema.get('properties', {})
+                      if 'model' in props:
+                          print(f'Model enum: {props[\"model\"].get(\"enum\", [])}')
+          " 2>/dev/null || echo "(parse error)"
+            echo '```' >> /tmp/docs_context.md
+            echo "" >> /tmp/docs_context.md
+          fi
+
+          # Suno guide docs
+          if [ -d guides/suno ]; then
+            echo "### Integration Guides (guides/suno/)" >> /tmp/docs_context.md
+            for f in guides/suno/*.mdx; do
+              if [ -f "$f" ]; then
+                echo "- $(basename "$f")" >> /tmp/docs_context.md
+              fi
+            done
+            echo "" >> /tmp/docs_context.md
+          fi
+
+          # MCP doc
+          if [ -f mcp/suno.mdx ]; then
+            echo "### MCP Doc (mcp/suno.mdx)" >> /tmp/docs_context.md
+            echo '```' >> /tmp/docs_context.md
+            head -80 mcp/suno.mdx >> /tmp/docs_context.md
+            echo '```' >> /tmp/docs_context.md
+          fi
+
+          cd ..
+
+          # Get the diff between Docs latest and what we might have cached
+          docs_context=$(cat /tmp/docs_context.md)
+          # Truncate if too long
+          if [ ${#docs_context} -gt 8000 ]; then
+            docs_context="${docs_context:0:8000}...(truncated)"
+          fi
+          # Write to a file for the next step
+          echo "$docs_context" > /tmp/docs_context_final.md
+
+      - name: Check for existing open sync issue
+        id: existing
+        env:
+          GH_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN }}
+        run: |
+          existing=$(gh issue list --label "auto-sync" --state open --json number --jq '.[0].number // empty')
+          if [ -n "$existing" ]; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            echo "issue_number=$existing" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create sync issue
+        if: steps.existing.outputs.exists != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN }}
+        run: |
+          docs_context=$(cat /tmp/docs_context_final.md)
+          commit_info="${{ steps.changes.outputs.commit_info }}"
+
+          body=$(cat <<'ISSUE_BODY'
+          @claude
+
+          The upstream **Docs** repository has been updated. Please review the changes below and update this MCP server accordingly.
+
+          ## What to Check
+
+          1. **Model versions** — Compare `core/types.py` (`SunoModel` Literal) against the OpenAPI spec's model enum. Add any missing models, remove any deprecated ones.
+          2. **Tool parameters** — Compare tool function signatures in `tools/` against the OpenAPI spec's request parameters. Add new parameters, update descriptions.
+          3. **Tool descriptions** — Update docstrings in `tools/*.py` to match the latest API descriptions from the guides.
+          4. **README.md** — Update features list, model table, and usage examples if new capabilities were added.
+          5. **Tests** — Add or update tests in `tests/` for any new functionality.
+
+          ## Instructions
+
+          - Only make changes if the Docs content shows new models, parameters, or capabilities not yet in this repo.
+          - If no changes are needed, close this issue with a comment explaining why.
+          - If changes are needed, create a PR with the updates.
+          - Keep changes minimal and focused — don't refactor unrelated code.
+          ISSUE_BODY
+          )
+
+          full_body=$(printf '%s\n\n## Docs Content\n\n%s' "$body" "$docs_context")
+
+          gh issue create \
+            --title "sync: update from Docs ($commit_info)" \
+            --label "auto-sync" \
+            --body "$full_body"
+
+      - name: Update existing issue
+        if: steps.existing.outputs.exists == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN }}
+        run: |
+          docs_context=$(cat /tmp/docs_context_final.md)
+          commit_info="${{ steps.changes.outputs.commit_info }}"
+
+          body=$(printf '@claude\n\nNew Docs update detected (%s). Please re-check and update if needed.\n\n%s' "$commit_info" "$docs_context")
+
+          gh issue comment "${{ steps.existing.outputs.issue_number }}" \
+            --body "$body"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,44 @@
+# MCPSuno
+
+MCP (Model Context Protocol) server for Suno AI music generation via AceDataCloud API.
+
+## Project Structure
+
+```
+core/
+  config.py     — Settings dataclass (API token, base URL)
+  server.py     — FastMCP server singleton
+  client.py     — httpx async HTTP client
+  types.py      — Literal types (SunoModel, VocalGender, etc.)
+  exceptions.py — Error classes (AuthError, APIError, TimeoutError)
+  utils.py      — Formatting helpers
+tools/
+  audio_tools.py   — generate, custom, extend, cover, remaster, concat
+  lyrics_tools.py  — generate lyrics, mashup
+  media_tools.py   — MP4, WAV, MIDI, timing, vocal separation
+  persona_tools.py — save/manage voice personas
+  style_tools.py   — optimize style descriptions
+  task_tools.py    — query task status, wait for completion
+  info_tools.py    — list models, capabilities
+prompts/           — LLM guidance prompts
+tests/             — pytest-asyncio + respx tests
+```
+
+## Sync from Docs
+
+When working on an auto-sync issue (labeled `auto-sync`), follow these rules:
+
+1. **Compare models** — The `SunoModel` Literal in `core/types.py` must match the model enum from the Docs OpenAPI spec. Add/remove model values as needed.
+2. **Compare parameters** — Each `@mcp.tool()` function's parameters should include all parameters from the corresponding OpenAPI endpoint. Use the Docs OpenAPI spec as source of truth.
+3. **Update defaults** — If a new model becomes the recommended default, update `DEFAULT_MODEL` in `core/types.py`.
+4. **Update README** — Keep the model table and feature list current.
+5. **Add tests** — For new tools or parameters, add test cases in `tests/`.
+6. **PR title** — Use format: `sync: <description> [auto-sync]`
+
+## Development
+
+```bash
+pip install -e ".[dev]"
+pytest --cov=core --cov=tools
+ruff check .
+```


### PR DESCRIPTION
Adds automated sync from Docs repo:
- **sync-from-docs.yml**: Receives `docs-updated` dispatch from Docs, creates issue with @claude to analyze changes and update this MCP server
- **auto-merge.yml**: Auto-approves and merges bot PRs after CI passes
- **CLAUDE.md**: Instructions for Claude Code on how to sync this repo

Part of the Docs cascade pipeline.