### PR TITLE
fix: support metadata 2.4 in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -107,13 +107,14 @@ jobs:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
         run: |
-          pip install "twine>=5.0.0,<6.0.0"
+          pip install "twine>=6.1.0,<7.0.0"
+          twine check dist/*
           twine upload dist/*
 
   create-release:
     name: Create GitHub Release
     if: github.event_name == 'push'
-    needs: [build, publish-pypi]
+    needs: build
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -174,7 +175,7 @@ jobs:
   publish-vscode:
     name: Publish VS Code Extension
     if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
-    needs: [build, publish-pypi]
+    needs: build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -298,7 +299,7 @@ jobs:
   notify-dify-plugin:
     name: Notify Dify Plugin Update
     if: github.event_name == 'push'
-    needs: [build, publish-pypi]
+    needs: build
     runs-on: ubuntu-latest
     steps:
       - name: Trigger Dify plugin sync
@@ -313,7 +314,7 @@ jobs:
   publish-jetbrains:
     name: Publish JetBrains Plugin
     if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
-    needs: [build, publish-pypi]
+    needs: build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Summary
- upgrade Twine in the publish workflow to a version that supports Python package metadata 2.4
- run twine check before upload so metadata issues fail with a clearer signal
- allow release, VS Code publish, Dify notification, and JetBrains publish to run after build instead of waiting on PyPI

## Validation
- reproduced the failure locally with Twine 5.x against the built distributions
- verified the same artifacts pass with Twine 6.x
- confirmed the failed GitHub artifact only contained the expected wheel and sdist
